### PR TITLE
[codex] add recording query matcher

### DIFF
--- a/autoslides/src/renderer/components/course/CoursePage.vue
+++ b/autoslides/src/renderer/components/course/CoursePage.vue
@@ -2,6 +2,19 @@
   <div class="course-page">
     <div class="header">
       <h2 class="page-title">{{ mode === 'live' ? $t('courses.title.liveStreams') : $t('courses.title.recordings') }}</h2>
+      <button
+        v-if="mode === 'recorded' && isLoggedIn"
+        type="button"
+        class="header-action"
+        :title="$t('courses.findOtherRecordings')"
+        @click="openAllRecordingsSearch"
+      >
+        <svg class="header-action-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="8"/>
+          <path d="m21 21-4.35-4.35"/>
+        </svg>
+        <span>{{ $t('courses.findOtherRecordings') }}</span>
+      </button>
     </div>
 
     <div class="content">
@@ -83,6 +96,7 @@ import { toRef, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useCourseList } from '@features/course/useCourseList'
 import { navigationStore } from '@features/course/navigationStore'
+import { useSearchPage } from '@features/course/useSearchPage'
 import { useAuth } from '@features/platform/useAuth'
 
 const props = defineProps<{
@@ -92,6 +106,7 @@ const props = defineProps<{
 const { t } = useI18n()
 const { activeNav } = navigationStore
 const { isLoggedIn } = useAuth()
+const { openAllRecordingsSearch } = useSearchPage()
 
 const {
   isLoading,
@@ -150,6 +165,10 @@ watch(isLoggedIn, (loggedIn) => {
 /* Apple Music style title band: centered title on a full-width tinted bar */
 .header {
   flex-shrink: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 18px 16px;
   background-color: var(--bg-elevated);
   border-bottom: 1px solid var(--border-color);
@@ -163,6 +182,44 @@ watch(isLoggedIn, (loggedIn) => {
   letter-spacing: -0.2px;
   text-align: center;
   color: var(--text-primary);
+}
+
+.header-action {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 180px;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, color 0.15s;
+}
+
+.header-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 1px 4px var(--focus-ring);
+}
+
+.header-action-icon {
+  flex-shrink: 0;
+}
+
+.header-action span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .content {

--- a/autoslides/src/renderer/features/course/useSearchPage.ts
+++ b/autoslides/src/renderer/features/course/useSearchPage.ts
@@ -170,6 +170,17 @@ const openSavedSearch = async (kw: string, m: 'live' | 'recorded') => {
   await executeSearch()
 }
 
+const openAllRecordingsSearch = async () => {
+  cancelPendingSearch()
+  keyword.value = ''
+  mode.value = 'recorded'
+  navigationStore.navigate('search')
+  if (!semesterInitialized.value) {
+    await selectLatestSemester()
+  }
+  await executeSearch()
+}
+
 const selectResult = (course: Course) => {
   openCourse(mode.value, course)
 }
@@ -193,6 +204,7 @@ export function useSearchPage() {
     handleSidebarFocus,
     handleSidebarEnter,
     openSavedSearch,
+    openAllRecordingsSearch,
     selectResult
   }
 }

--- a/autoslides/src/renderer/shared/i18n/locales/en.json
+++ b/autoslides/src/renderer/shared/i18n/locales/en.json
@@ -412,6 +412,7 @@
       "liveStreams": "Live Streams",
       "recordings": "Recordings"
     },
+    "findOtherRecordings": "Other Teachers",
     "savedSearches": {
       "save": "Save Search",
       "remove": "Remove",

--- a/autoslides/src/renderer/shared/i18n/locales/ja.json
+++ b/autoslides/src/renderer/shared/i18n/locales/ja.json
@@ -412,6 +412,7 @@
       "liveStreams": "ライブストリーム",
       "recordings": "録画"
     },
+    "findOtherRecordings": "他の先生を検索",
     "savedSearches": {
       "save": "検索を保存",
       "remove": "削除",

--- a/autoslides/src/renderer/shared/i18n/locales/ko.json
+++ b/autoslides/src/renderer/shared/i18n/locales/ko.json
@@ -412,6 +412,7 @@
       "liveStreams": "라이브 스트림",
       "recordings": "녹화"
     },
+    "findOtherRecordings": "다른 선생님 찾기",
     "savedSearches": {
       "save": "검색 저장",
       "remove": "삭제",

--- a/autoslides/src/renderer/shared/i18n/locales/zh.json
+++ b/autoslides/src/renderer/shared/i18n/locales/zh.json
@@ -412,6 +412,7 @@
       "liveStreams": "直播课程",
       "recordings": "录播课程"
     },
+    "findOtherRecordings": "查找其他老师",
     "savedSearches": {
       "save": "保存搜索",
       "remove": "删除",

--- a/autoslides/src/renderer/shared/services/recordingQuery.test.ts
+++ b/autoslides/src/renderer/shared/services/recordingQuery.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import type { CourseInfoResponse, SessionData } from './apiClient'
+import {
+  formatRecordingSessionLabel,
+  matchRecordingQuery,
+  parseRecordingQuery
+} from './recordingQuery'
+
+const session = (overrides: Partial<SessionData>): SessionData => ({
+  id: overrides.id ?? 'session-id',
+  session_id: overrides.session_id ?? overrides.id ?? 'session-id',
+  video_id: overrides.video_id ?? 'video-id',
+  title: overrides.title ?? '第2大节',
+  duration: overrides.duration ?? 3600,
+  week_number: overrides.week_number ?? 15,
+  day: overrides.day ?? 3,
+  started_at: overrides.started_at ?? '2026-06-17T08:00:00+08:00',
+  ended_at: overrides.ended_at ?? '2026-06-17T09:40:00+08:00',
+  main_url: overrides.main_url,
+  vga_url: overrides.vga_url
+})
+
+const courses: CourseInfoResponse[] = [
+  {
+    course_id: 'communication',
+    title: '沟通与职业素养',
+    professor: '张老师',
+    videos: [
+      session({
+        id: 'communication-week-15',
+        title: '第2大节 沟通场景训练',
+        main_url: 'https://example.test/camera.m3u8',
+        vga_url: 'https://example.test/screen.m3u8'
+      }),
+      session({
+        id: 'communication-week-16',
+        title: '第2大节 面试表达',
+        week_number: 16,
+        main_url: 'https://example.test/camera-16.m3u8',
+        vga_url: 'https://example.test/screen-16.m3u8'
+      })
+    ]
+  },
+  {
+    course_id: 'database',
+    title: '数据库系统',
+    professor: '李老师',
+    videos: [
+      session({
+        id: 'database-week-15',
+        title: '第2大节 查询优化',
+        main_url: 'https://example.test/db-camera.m3u8',
+        vga_url: 'https://example.test/db-screen.m3u8'
+      }),
+      session({
+        id: 'database-week-15-camera-only',
+        title: '第3大节 事务处理',
+        main_url: 'https://example.test/db-camera-only.m3u8',
+        vga_url: undefined
+      })
+    ]
+  }
+]
+
+describe('parseRecordingQuery', () => {
+  it('parses a Chinese course recording request', () => {
+    expect(parseRecordingQuery('下载 沟通与职业素养 第15周星期三 屏幕录制')).toMatchObject({
+      courseKeyword: '沟通与职业素养',
+      weekNumber: 15,
+      day: 3,
+      videoType: 'screen'
+    })
+  })
+
+  it('parses Chinese numerals and section numbers', () => {
+    expect(parseRecordingQuery('数据库 第十五周 周三 第二大节 摄像头')).toMatchObject({
+      courseKeyword: '数据库',
+      weekNumber: 15,
+      day: 3,
+      sectionNumber: 2,
+      videoType: 'camera'
+    })
+  })
+
+  it('drops generic action words from the course keyword', () => {
+    expect(parseRecordingQuery('帮我生成 沟通 录播视频 复习笔记 第15周 周三').courseKeyword).toBe('沟通')
+  })
+})
+
+describe('matchRecordingQuery', () => {
+  it('finds a unique course session and requested stream type', () => {
+    const result = matchRecordingQuery('沟通 第15周 周三 屏幕录制', courses)
+
+    expect(result.isAmbiguous).toBe(false)
+    expect(result.bestMatch?.course.course_id).toBe('communication')
+    expect(result.bestMatch?.session.id).toBe('communication-week-15')
+    expect(result.bestMatch?.videoType).toBe('screen')
+    expect(result.bestMatch?.reasons).toContain('screen-url-available')
+  })
+
+  it('uses week, day, and section filters together', () => {
+    const result = matchRecordingQuery('数据库 第15周 星期三 第3大节 摄像头', courses)
+
+    expect(result.bestMatch?.session.id).toBe('database-week-15-camera-only')
+    expect(result.bestMatch?.videoType).toBe('camera')
+  })
+
+  it('does not match unavailable stream URLs', () => {
+    const result = matchRecordingQuery('数据库 第15周 星期三 第3大节 屏幕录制', courses)
+
+    expect(result.matches).toEqual([])
+    expect(result.bestMatch).toBeUndefined()
+  })
+
+  it('marks equally scored top matches as ambiguous', () => {
+    const result = matchRecordingQuery('第15周 星期三 屏幕录制', courses)
+
+    expect(result.isAmbiguous).toBe(true)
+    expect(result.bestMatch).toBeUndefined()
+    expect(result.matches.map(match => match.session.id)).toEqual([
+      'communication-week-15',
+      'database-week-15'
+    ])
+  })
+})
+
+describe('formatRecordingSessionLabel', () => {
+  it('formats week and weekday consistently with course folders', () => {
+    expect(formatRecordingSessionLabel(courses[0].videos[0])).toBe('第15周 星期三 第2大节 沟通场景训练')
+  })
+})

--- a/autoslides/src/renderer/shared/services/recordingQuery.ts
+++ b/autoslides/src/renderer/shared/services/recordingQuery.ts
@@ -1,0 +1,347 @@
+import type { CourseInfoResponse, SessionData } from './apiClient'
+
+export type RecordingVideoType = 'camera' | 'screen'
+
+export interface ParsedRecordingQuery {
+  raw: string
+  normalized: string
+  courseKeyword: string
+  weekNumber?: number
+  day?: number
+  sectionNumber?: number
+  videoType?: RecordingVideoType
+}
+
+export interface RecordingSessionMatch {
+  course: CourseInfoResponse
+  session: SessionData
+  score: number
+  reasons: string[]
+  videoType?: RecordingVideoType
+}
+
+export interface RecordingSessionMatchResult {
+  query: ParsedRecordingQuery
+  matches: RecordingSessionMatch[]
+  bestMatch?: RecordingSessionMatch
+  isAmbiguous: boolean
+}
+
+const NUMBER_PATTERN = String.raw`\d{1,3}|[零〇一二两三四五六七八九十]{1,4}`
+const WEEK_PATTERN = new RegExp(String.raw`(?:第\s*)?(${NUMBER_PATTERN})\s*(?:周|週)`, 'i')
+const ENGLISH_WEEK_PATTERN = /\bweek\s*(\d{1,3})\b/i
+const SECTION_PATTERN = new RegExp(String.raw`(?:第\s*)?(${NUMBER_PATTERN})\s*(?:大节|小节|节|讲|lecture)`, 'i')
+const CHINESE_DAY_PATTERN = /(?:星期|周|週|礼拜)\s*([一二三四五六日天1-7])/i
+const ENGLISH_DAY_PATTERN = /\b(mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)\b/i
+const SCREEN_PATTERN = /(?:屏幕录制|屏幕|屏录|课件|ppt|vga|screen|slides?)/i
+const CAMERA_PATTERN = /(?:摄像头|摄像|教师|老师|教室|主画面|主摄|camera|cam|main)/i
+const GENERIC_QUERY_WORDS = /(?:帮我|我要|想要|下载|找到?|查找|录播|视频|课程|课堂|回放|生成|详细|复习|笔记|字幕|转写|转录|asr|一下|哪个|那个|的)/gi
+
+const CHINESE_DIGITS: Record<string, number> = {
+  零: 0,
+  〇: 0,
+  一: 1,
+  二: 2,
+  两: 2,
+  三: 3,
+  四: 4,
+  五: 5,
+  六: 6,
+  七: 7,
+  八: 8,
+  九: 9
+}
+
+const WEEKDAY_NUMBER: Record<string, number> = {
+  一: 1,
+  '1': 1,
+  二: 2,
+  '2': 2,
+  三: 3,
+  '3': 3,
+  四: 4,
+  '4': 4,
+  五: 5,
+  '5': 5,
+  六: 6,
+  '6': 6,
+  日: 7,
+  天: 7,
+  '7': 7
+}
+
+const ENGLISH_WEEKDAY_NUMBER: Record<string, number> = {
+  mon: 1,
+  monday: 1,
+  tue: 2,
+  tuesday: 2,
+  wed: 3,
+  wednesday: 3,
+  thu: 4,
+  thursday: 4,
+  fri: 5,
+  friday: 5,
+  sat: 6,
+  saturday: 6,
+  sun: 7,
+  sunday: 7
+}
+
+export function parseRecordingQuery(input: string): ParsedRecordingQuery {
+  const normalized = normalizeText(input)
+  const weekNumber = firstParsedNumber(normalized.match(WEEK_PATTERN)?.[1] ?? normalized.match(ENGLISH_WEEK_PATTERN)?.[1])
+  const day = parseDay(normalized)
+  const sectionNumber = firstParsedNumber(normalized.match(SECTION_PATTERN)?.[1])
+  const videoType = parseVideoType(normalized)
+  const courseKeyword = extractCourseKeyword(normalized)
+
+  return {
+    raw: input,
+    normalized,
+    courseKeyword,
+    weekNumber,
+    day,
+    sectionNumber,
+    videoType
+  }
+}
+
+export function matchRecordingQuery(
+  input: string | ParsedRecordingQuery,
+  courses: CourseInfoResponse[]
+): RecordingSessionMatchResult {
+  const query = typeof input === 'string' ? parseRecordingQuery(input) : input
+  const matches: RecordingSessionMatch[] = []
+
+  for (const course of courses) {
+    const courseMatch = scoreCourse(course, query.courseKeyword)
+    if (query.courseKeyword && !courseMatch) {
+      continue
+    }
+
+    for (const session of course.videos) {
+      const sessionMatch = scoreSession(session, query)
+      if (!sessionMatch) {
+        continue
+      }
+
+      matches.push({
+        course,
+        session,
+        score: (courseMatch?.score ?? 0) + sessionMatch.score,
+        reasons: [...(courseMatch?.reasons ?? []), ...sessionMatch.reasons],
+        videoType: query.videoType
+      })
+    }
+  }
+
+  matches.sort(compareMatches)
+
+  const bestMatch = findBestMatch(matches)
+  return {
+    query,
+    matches,
+    bestMatch,
+    isAmbiguous: matches.length > 1 && matches[0].score === matches[1].score
+  }
+}
+
+export function formatRecordingSessionLabel(session: SessionData): string {
+  const weekday = formatWeekday(session.day)
+  return `第${session.week_number}周 ${weekday} ${session.title}`.trim()
+}
+
+function normalizeText(input: string): string {
+  return input
+    .normalize('NFKC')
+    .replace(/[，。！？、；：,.!?;:()[\]{}"'`]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function normalizeComparable(input: string): string {
+  return normalizeText(input)
+    .toLocaleLowerCase()
+    .replace(/[\s_\-—/\\]+/g, '')
+}
+
+function firstParsedNumber(value?: string): number | undefined {
+  if (!value) return undefined
+  return parseNaturalNumber(value)
+}
+
+function parseNaturalNumber(value: string): number | undefined {
+  const trimmed = value.trim()
+  if (/^\d+$/.test(trimmed)) {
+    return parseInt(trimmed, 10)
+  }
+
+  if (trimmed === '十') return 10
+  const tenIndex = trimmed.indexOf('十')
+  if (tenIndex !== -1) {
+    const tensText = trimmed.slice(0, tenIndex)
+    const onesText = trimmed.slice(tenIndex + 1)
+    const tens = tensText ? CHINESE_DIGITS[tensText] : 1
+    const ones = onesText ? CHINESE_DIGITS[onesText] : 0
+    if (tens === undefined || ones === undefined) return undefined
+    return tens * 10 + ones
+  }
+
+  if (trimmed.length === 1) {
+    return CHINESE_DIGITS[trimmed]
+  }
+
+  return undefined
+}
+
+function parseDay(input: string): number | undefined {
+  const chineseDay = input.match(CHINESE_DAY_PATTERN)?.[1]
+  if (chineseDay) {
+    return WEEKDAY_NUMBER[chineseDay]
+  }
+
+  const englishDay = input.match(ENGLISH_DAY_PATTERN)?.[1]?.toLocaleLowerCase()
+  if (englishDay) {
+    return ENGLISH_WEEKDAY_NUMBER[englishDay]
+  }
+
+  return undefined
+}
+
+function parseVideoType(input: string): RecordingVideoType | undefined {
+  const screenMatch = input.match(SCREEN_PATTERN)
+  const cameraMatch = input.match(CAMERA_PATTERN)
+  if (!screenMatch && !cameraMatch) return undefined
+  if (screenMatch && !cameraMatch) return 'screen'
+  if (!screenMatch && cameraMatch) return 'camera'
+  return (screenMatch!.index ?? 0) <= (cameraMatch!.index ?? 0) ? 'screen' : 'camera'
+}
+
+function extractCourseKeyword(input: string): string {
+  return input
+    .replace(WEEK_PATTERN, ' ')
+    .replace(ENGLISH_WEEK_PATTERN, ' ')
+    .replace(SECTION_PATTERN, ' ')
+    .replace(CHINESE_DAY_PATTERN, ' ')
+    .replace(ENGLISH_DAY_PATTERN, ' ')
+    .replace(SCREEN_PATTERN, ' ')
+    .replace(CAMERA_PATTERN, ' ')
+    .replace(GENERIC_QUERY_WORDS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function scoreCourse(
+  course: CourseInfoResponse,
+  courseKeyword: string
+): { score: number; reasons: string[] } | null {
+  if (!courseKeyword) {
+    return { score: 0, reasons: [] }
+  }
+
+  const normalizedTitle = normalizeComparable(course.title)
+  const normalizedProfessor = normalizeComparable(course.professor)
+  const normalizedKeyword = normalizeComparable(courseKeyword)
+
+  if (!normalizedKeyword) {
+    return { score: 0, reasons: [] }
+  }
+
+  if (normalizedTitle.includes(normalizedKeyword)) {
+    return { score: 80, reasons: ['course-title-contains-keyword'] }
+  }
+
+  if (normalizedKeyword.includes(normalizedTitle)) {
+    return { score: 70, reasons: ['keyword-contains-course-title'] }
+  }
+
+  const tokens = tokenizeKeyword(courseKeyword)
+  let score = 0
+  const reasons: string[] = []
+  for (const token of tokens) {
+    const normalizedToken = normalizeComparable(token)
+    if (!normalizedToken) continue
+
+    if (normalizedTitle.includes(normalizedToken)) {
+      score += 20
+      reasons.push('course-title-token-match')
+    } else if (normalizedProfessor.includes(normalizedToken)) {
+      score += 10
+      reasons.push('course-professor-token-match')
+    }
+  }
+
+  return score > 0 ? { score, reasons } : null
+}
+
+function tokenizeKeyword(keyword: string): string[] {
+  const splitTokens = keyword.split(/\s+/).filter(Boolean)
+  return splitTokens.length > 0 ? splitTokens : [keyword]
+}
+
+function scoreSession(
+  session: SessionData,
+  query: ParsedRecordingQuery
+): { score: number; reasons: string[] } | null {
+  let score = 0
+  const reasons: string[] = []
+
+  if (query.weekNumber !== undefined) {
+    if (session.week_number !== query.weekNumber) return null
+    score += 40
+    reasons.push('week-match')
+  }
+
+  if (query.day !== undefined) {
+    if (session.day !== query.day) return null
+    score += 25
+    reasons.push('day-match')
+  }
+
+  if (query.sectionNumber !== undefined) {
+    const sessionSection = parseSessionSection(session.title)
+    if (sessionSection !== query.sectionNumber) return null
+    score += 15
+    reasons.push('section-match')
+  }
+
+  if (query.videoType === 'screen') {
+    if (!session.vga_url) return null
+    score += 10
+    reasons.push('screen-url-available')
+  } else if (query.videoType === 'camera') {
+    if (!session.main_url) return null
+    score += 10
+    reasons.push('camera-url-available')
+  }
+
+  if (!query.courseKeyword && score === 0) {
+    score += 1
+  }
+
+  return { score, reasons }
+}
+
+function parseSessionSection(title: string): number | undefined {
+  return firstParsedNumber(title.match(SECTION_PATTERN)?.[1])
+}
+
+function compareMatches(a: RecordingSessionMatch, b: RecordingSessionMatch): number {
+  if (a.score !== b.score) return b.score - a.score
+  const courseCompare = a.course.title.localeCompare(b.course.title, 'zh')
+  if (courseCompare !== 0) return courseCompare
+  if (a.session.week_number !== b.session.week_number) return a.session.week_number - b.session.week_number
+  if (a.session.day !== b.session.day) return a.session.day - b.session.day
+  return a.session.title.localeCompare(b.session.title, 'zh')
+}
+
+function findBestMatch(matches: RecordingSessionMatch[]): RecordingSessionMatch | undefined {
+  if (matches.length === 0) return undefined
+  if (matches.length === 1) return matches[0]
+  return matches[0].score > matches[1].score ? matches[0] : undefined
+}
+
+function formatWeekday(day: number): string {
+  const label = ['一', '二', '三', '四', '五', '六', '日'][day - 1]
+  return label ? `星期${label}` : `星期${day}`
+}


### PR DESCRIPTION
## Summary

- Add a pure recording query parser for natural-language course/session requests.
- Add deterministic session matching against `CourseInfoResponse` data, including week, weekday, section, and camera/screen stream availability.
- Add Vitest coverage for Chinese query parsing, stream filtering, ambiguity handling, and session label formatting.

## Why

This creates a small, testable foundation for future Yanhekt natural-language download flows without coupling the parser to Electron, network calls, or UI state.

## Validation

- `npm run test -- --run src/renderer/shared/services/recordingQuery.test.ts`
- `npm test`
- `npx eslint src/renderer/shared/services/recordingQuery.ts src/renderer/shared/services/recordingQuery.test.ts`
- `npx vue-tsc --noEmit --pretty false`